### PR TITLE
fix: allow OP_ISA_ASM as block terminator for naked asm functions

### DIFF
--- a/src/verify.mach
+++ b/src/verify.mach
@@ -96,6 +96,7 @@ fun is_terminator(o: u8, cc: u8, flag: u8) bool {
     if (o == op.OP_RET)  { ret true; }
     if (o == op.OP_TRAP) { ret true; }
     if (o == op.OP_BRANCH) { ret true; }
+    if (o == op.OP_ISA_ASM) { ret true; }
     if (o == op.OP_CALL && cc == op.CALL_TAIL && flag == 0) { ret true; }
     if (o == op.OP_CALL && cc == op.CALL_TAIL && flag == 1) { ret true; }
     ret false;


### PR DESCRIPTION
ISA asm blocks can be the last instruction in a block when the asm handles its own exit (e.g., `_start` which ends with `syscall` for SYS_exit). Reverses part of #83 that removed this.