### PR TITLE
fix: rebuild against current compiler/std and fix drift

### DIFF
--- a/src/cfg.mach
+++ b/src/cfg.mach
@@ -4,12 +4,18 @@
 # already exist with labels and instructions — the CFG adds
 # predecessor/successor edges as a parallel data structure.
 
-use std.types.bool;
-use std.types.size;
-use std.types.string;
-use std.types.result;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.is_err;
+use std.types.result.is_ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use map:       std.collections.map;
 
 use fn:   masm.function;
@@ -833,17 +839,19 @@ fun alloc_block(alloc: *allocator.Allocator, label: str) *fn.Block {
 }
 
 test "cfg: empty function produces empty CFG" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "empty");
     var cfg: CFG = build_cfg(?a, ?f);
     fn.func_dnit(?a, ?f);
-    if (cfg.block_count != 0) { ret 0; }
-    if (cfg.blocks != nil) { ret 0; }
-    ret 1;
+    if (cfg.block_count != 0) { ret 1; }
+    if (cfg.blocks != nil) { ret 1; }
+    ret 0;
 }
 
 test "cfg: linear chain A->B->C" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "chain");
 
     val lb: i32 = pool.label_intern(?a, ?f.labels, "b");
@@ -863,31 +871,32 @@ test "cfg: linear chain A->B->C" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 3) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 3) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # A: 0 preds, 1 succ (B)
-    if (cfg.blocks[0].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].succs[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.blocks[0].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].succs[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # B: 1 pred (A), 1 succ (C)
-    if (cfg.blocks[1].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[1].preds[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[1].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[1].succs[0] != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.blocks[1].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[1].preds[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[1].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[1].succs[0] != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # C: 1 pred (B), 0 succs
-    if (cfg.blocks[2].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[2].preds[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[2].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.blocks[2].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[2].preds[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[2].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "cfg: diamond branch A->{B,C}->D" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "diamond");
 
     val lb: i32 = pool.label_intern(?a, ?f.labels, "b");
@@ -916,23 +925,24 @@ test "cfg: diamond branch A->{B,C}->D" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 4) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 4) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # A: 0 preds, 2 succs (C=2, B=1 fallthrough)
-    if (cfg.blocks[0].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.blocks[0].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # D: 2 preds (B and C), 0 succs
-    if (cfg.blocks[3].npreds != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[3].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.blocks[3].npreds != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[3].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "cfg: self-loop" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "loop");
 
     val la: i32 = pool.label_intern(?a, ?f.labels, "a");
@@ -943,19 +953,20 @@ test "cfg: self-loop" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].succs[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].preds[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].succs[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].preds[0] != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "cfg: tail call has no successors" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "tail");
 
     val lt: i32 = pool.label_intern(?a, ?f.labels, "target");
@@ -966,16 +977,17 @@ test "cfg: tail call has no successors" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "cfg: trap has no successors" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "trap");
 
     var ba: *fn.Block = alloc_block(?a, "a");
@@ -988,17 +1000,18 @@ test "cfg: trap has no successors" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[1].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[1].npreds != 0) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "cfg: fallthrough on non-terminator" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "fall");
 
     var ba: *fn.Block = alloc_block(?a, "a");
@@ -1011,18 +1024,19 @@ test "cfg: fallthrough on non-terminator" {
 
     var cfg: CFG = build_cfg(?a, ?f);
 
-    if (cfg.block_count != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[0].succs[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (cfg.blocks[1].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (cfg.block_count != 2) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].nsuccs != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[0].succs[0] != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (cfg.blocks[1].npreds != 1) { cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "dom: linear chain A dominates all" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "chain");
 
     val lb: i32 = pool.label_intern(?a, ?f.labels, "b");
@@ -1043,33 +1057,34 @@ test "dom: linear chain A dominates all" {
     var cfg: CFG = build_cfg(?a, ?f);
     var dom: DomInfo = compute_dominance(?a, ?cfg);
 
-    if (dom.rpo_count != 3) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dom.rpo_count != 3) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # A dominates all
-    if (dominates(?dom, 0, 0) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 0, 0) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # B dominates C
-    if (dominates(?dom, 1, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 1, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # C does not dominate A or B
-    if (dominates(?dom, 2, 0)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 2, 0)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # idom checks
-    if (dom.idom[0] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dom.idom[1] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dom.idom[2] != 1) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dom.idom[0] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dom.idom[1] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dom.idom[2] != 1) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     dom_dnit(?a, ?dom);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "dom: diamond idom converges to entry" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "diamond");
 
     val lc: i32 = pool.label_intern(?a, ?f.labels, "c");
@@ -1095,27 +1110,28 @@ test "dom: diamond idom converges to entry" {
     var dom: DomInfo = compute_dominance(?a, ?cfg);
 
     # A dominates all
-    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # B and C don't dominate each other
-    if (dominates(?dom, 1, 2)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 1, 2)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # D's idom is A (both paths merge)
-    if (dom.idom[3] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dom.idom[1] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dom.idom[2] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dom.idom[3] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dom.idom[1] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dom.idom[2] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     dom_dnit(?a, ?dom);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "dom: single block" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "single");
 
     var ba: *fn.Block = alloc_block(?a, "a");
@@ -1125,18 +1141,19 @@ test "dom: single block" {
     var cfg: CFG = build_cfg(?a, ?f);
     var dom: DomInfo = compute_dominance(?a, ?cfg);
 
-    if (dom.rpo_count != 1) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dom.idom[0] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 0) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dom.rpo_count != 1) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dom.idom[0] != 0) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 0) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     dom_dnit(?a, ?dom);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "dom: loop header dominates body" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "loop");
 
     val lh: i32 = pool.label_intern(?a, ?f.labels, "header");
@@ -1163,25 +1180,26 @@ test "dom: loop header dominates body" {
     var dom: DomInfo = compute_dominance(?a, ?cfg);
 
     # entry dominates all
-    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 0, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 0, 1) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 0, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # header dominates body and exit
-    if (dominates(?dom, 1, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (dominates(?dom, 1, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 1, 2) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (dominates(?dom, 1, 3) == false) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     # body does not dominate header (back edge)
-    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (dominates(?dom, 2, 1)) { dom_dnit(?a, ?dom); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     dom_dnit(?a, ?dom);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "live: register live across blocks" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "cross");
 
     val lb: i32 = pool.label_intern(?a, ?f.labels, "b");
@@ -1200,21 +1218,22 @@ test "live: register live across blocks" {
     var ls: LiveSets = compute_liveness(?a, ?cfg, ?f);
 
     # r32 live out of A, live in to B
-    if (is_live_out(?ls, 0, 32) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (is_live_in(?ls, 1, 32) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (is_live_out(?ls, 0, 32) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (is_live_in(?ls, 1, 32) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
     # r32 not live out of B (consumed)
-    if (is_live_out(?ls, 1, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (is_live_out(?ls, 1, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
     # r33 live in to A (used, not defined before)
-    if (is_live_in(?ls, 0, 33) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (is_live_in(?ls, 0, 33) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     live_dnit(?a, ?ls);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }
 
 test "live: dead def not live" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var f: fn.Function = fn.func_init(?a, "dead");
 
     var ba: *fn.Block = alloc_block(?a, "a");
@@ -1226,14 +1245,14 @@ test "live: dead def not live" {
     var ls: LiveSets = compute_liveness(?a, ?cfg, ?f);
 
     # r32 not live (dead def, never used)
-    if (is_live_out(?ls, 0, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (is_live_in(?ls, 0, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (is_live_out(?ls, 0, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (is_live_in(?ls, 0, 32)) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
     # r33 and r34 are live_in (used as sources)
-    if (is_live_in(?ls, 0, 33) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
-    if (is_live_in(?ls, 0, 34) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 0; }
+    if (is_live_in(?ls, 0, 33) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
+    if (is_live_in(?ls, 0, 34) == false) { live_dnit(?a, ?ls); cfg_dnit(?a, ?cfg); fn.func_dnit(?a, ?f); ret 1; }
 
     live_dnit(?a, ?ls);
     cfg_dnit(?a, ?cfg);
     fn.func_dnit(?a, ?f);
-    ret 1;
+    ret 0;
 }

--- a/src/codec.mach
+++ b/src/codec.mach
@@ -4,13 +4,21 @@
 # human-readable .masm text format. single public module — consumers
 # import masm.codec and use the top-level functions.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_err;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_equals;
 
 use allocator: std.allocator;
-use bytebuf:   std.io.bytebuf;
+use page:      std.allocator.page;
+use bytebuf:   std.io.buffer;
 use fs:        std.filesystem;
 
 use op:      masm.op;
@@ -53,8 +61,8 @@ pub fun encode_file(alloc: *allocator.Allocator, m: *mod.Module, path: str) Resu
     }
 
     var f: fs.File = unwrap_ok[fs.File, str](fr);
-    val wr: Result[usize, str] = fs.file_write(?f, buf.data, buf.len);
-    fs.file_close(?f);
+    val wr: Result[usize, str] = fs.write(?f, buf.data, buf.len);
+    fs.close(?f);
     bytebuf.wbuf_dnit(?buf);
 
     if (is_err[usize, str](wr)) {
@@ -86,24 +94,24 @@ pub fun decode_file(alloc: *allocator.Allocator, path: str) Result[mod.Module, s
     }
     var f: fs.File = unwrap_ok[fs.File, str](fr);
 
-    val sr: Result[fs.Stat, str] = fs.file_stat(?f);
-    if (is_err[fs.Stat, str](sr)) {
-        fs.file_close(?f);
-        ret err[mod.Module, str](unwrap_err[fs.Stat, str](sr));
+    val sr: Result[fs.FileInfo, str] = fs.info(?f);
+    if (is_err[fs.FileInfo, str](sr)) {
+        fs.close(?f);
+        ret err[mod.Module, str](unwrap_err[fs.FileInfo, str](sr));
     }
-    val st: fs.Stat = unwrap_ok[fs.Stat, str](sr);
-    val size: usize = st.st_size::usize;
+    val st: fs.FileInfo = unwrap_ok[fs.FileInfo, str](sr);
+    val size: usize = st.size;
 
     val ar: Result[*u8, str] =
         allocator.allocate[u8](alloc, size);
     if (is_err[*u8, str](ar)) {
-        fs.file_close(?f);
+        fs.close(?f);
         ret err[mod.Module, str]("alloc failed");
     }
     val buf: *u8 = unwrap_ok[*u8, str](ar);
 
-    val rr: Result[usize, str] = fs.file_read(?f, buf, size);
-    fs.file_close(?f);
+    val rr: Result[usize, str] = fs.read(?f, buf, size);
+    fs.close(?f);
     if (is_err[usize, str](rr)) {
         allocator.deallocate[u8](alloc, buf, size);
         ret err[mod.Module, str](unwrap_err[usize, str](rr));
@@ -135,8 +143,8 @@ pub fun print_file(alloc: *allocator.Allocator, m: *mod.Module, path: str) Resul
     }
 
     var f: fs.File = unwrap_ok[fs.File, str](fr);
-    val wr: Result[usize, str] = fs.file_write(?f, buf.data, buf.len);
-    fs.file_close(?f);
+    val wr: Result[usize, str] = fs.write(?f, buf.data, buf.len);
+    fs.close(?f);
     bytebuf.wbuf_dnit(?buf);
 
     if (is_err[usize, str](wr)) {
@@ -168,24 +176,24 @@ pub fun parse_file(alloc: *allocator.Allocator, path: str) Result[mod.Module, st
     }
     var f: fs.File = unwrap_ok[fs.File, str](fr);
 
-    val sr: Result[fs.Stat, str] = fs.file_stat(?f);
-    if (is_err[fs.Stat, str](sr)) {
-        fs.file_close(?f);
-        ret err[mod.Module, str](unwrap_err[fs.Stat, str](sr));
+    val sr: Result[fs.FileInfo, str] = fs.info(?f);
+    if (is_err[fs.FileInfo, str](sr)) {
+        fs.close(?f);
+        ret err[mod.Module, str](unwrap_err[fs.FileInfo, str](sr));
     }
-    val st: fs.Stat = unwrap_ok[fs.Stat, str](sr);
-    val size: usize = st.st_size::usize;
+    val st: fs.FileInfo = unwrap_ok[fs.FileInfo, str](sr);
+    val size: usize = st.size;
 
     val ar: Result[*u8, str] =
         allocator.allocate[u8](alloc, size);
     if (is_err[*u8, str](ar)) {
-        fs.file_close(?f);
+        fs.close(?f);
         ret err[mod.Module, str]("alloc failed");
     }
     val buf: *u8 = unwrap_ok[*u8, str](ar);
 
-    val rr: Result[usize, str] = fs.file_read(?f, buf, size);
-    fs.file_close(?f);
+    val rr: Result[usize, str] = fs.read(?f, buf, size);
+    fs.close(?f);
     if (is_err[usize, str](rr)) {
         allocator.deallocate[u8](alloc, buf, size);
         ret err[mod.Module, str](unwrap_err[usize, str](rr));
@@ -226,131 +234,139 @@ fun build_test_module(alloc: *allocator.Allocator) mod.Module {
 }
 
 test "codec: binary round-trip preserves function count" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val er: Result[bytebuf.WriteBuf, str] = encode(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](er)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](er)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](er);
     val dr: Result[mod.Module, str] = decode(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len == 1) { ret 1; }
-    ret 0;
+    if (m2.functions.len == 1) { ret 0; }
+    ret 1;
 }
 
 test "codec: binary round-trip preserves function name" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val er: Result[bytebuf.WriteBuf, str] = encode(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](er)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](er)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](er);
     val dr: Result[mod.Module, str] = decode(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
-    if (str_equals(m2.functions.data[0].name, "test_fn")) { ret 1; }
-    ret 0;
+    if (m2.functions.len < 1) { ret 1; }
+    if (str_equals(m2.functions.data[0].name, "test_fn")) { ret 0; }
+    ret 1;
 }
 
 test "codec: binary round-trip preserves instruction count" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val er: Result[bytebuf.WriteBuf, str] = encode(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](er)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](er)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](er);
     val dr: Result[mod.Module, str] = decode(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
+    if (m2.functions.len < 1) { ret 1; }
     val f: *fn.Function = m2.functions.data[0];
-    if (f.blocks.len < 1) { ret 0; }
-    if (f.blocks.data[0].inst_count == 5) { ret 1; }
-    ret 0;
+    if (f.blocks.len < 1) { ret 1; }
+    if (f.blocks.data[0].inst_count == 5) { ret 0; }
+    ret 1;
 }
 
 test "codec: binary round-trip preserves opcode sequence" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val er: Result[bytebuf.WriteBuf, str] = encode(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](er)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](er)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](er);
     val dr: Result[mod.Module, str] = decode(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
+    if (m2.functions.len < 1) { ret 1; }
     val f: *fn.Function = m2.functions.data[0];
-    if (f.blocks.len < 1) { ret 0; }
+    if (f.blocks.len < 1) { ret 1; }
     val b: *fn.Block = f.blocks.data[0];
-    if (b.inst_count != 5) { ret 0; }
-    if (b.insts[0].op != op.OP_LABEL) { ret 0; }
-    if (b.insts[1].op != op.OP_MOVE) { ret 0; }
-    if (b.insts[2].op != op.OP_LOAD) { ret 0; }
-    if (b.insts[3].op != op.OP_ADD) { ret 0; }
-    if (b.insts[4].op != op.OP_RET) { ret 0; }
-    ret 1;
+    if (b.inst_count != 5) { ret 1; }
+    if (b.insts[0].op != op.OP_LABEL) { ret 1; }
+    if (b.insts[1].op != op.OP_MOVE) { ret 1; }
+    if (b.insts[2].op != op.OP_LOAD) { ret 1; }
+    if (b.insts[3].op != op.OP_ADD) { ret 1; }
+    if (b.insts[4].op != op.OP_RET) { ret 1; }
+    ret 0;
 }
 
 test "codec: binary round-trip preserves const pool values" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val er: Result[bytebuf.WriteBuf, str] = encode(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](er)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](er)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](er);
     val dr: Result[mod.Module, str] = decode(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
+    if (m2.functions.len < 1) { ret 1; }
     val v: u64 = pool.const_get(?m2.functions.data[0].const_pool, 0);
-    if (v == 42) { ret 1; }
-    ret 0;
+    if (v == 42) { ret 0; }
+    ret 1;
 }
 
 test "codec: text round-trip preserves function count" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val pr: Result[bytebuf.WriteBuf, str] = printer.print(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](pr);
     val dr: Result[mod.Module, str] = parse(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len == 1) { ret 1; }
-    ret 0;
+    if (m2.functions.len == 1) { ret 0; }
+    ret 1;
 }
 
 test "codec: text round-trip preserves instruction count" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val pr: Result[bytebuf.WriteBuf, str] = printer.print(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](pr);
     val dr: Result[mod.Module, str] = parse(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
+    if (m2.functions.len < 1) { ret 1; }
     val f: *fn.Function = m2.functions.data[0];
-    if (f.blocks.len < 1) { ret 0; }
-    if (f.blocks.data[0].inst_count == 4) { ret 1; }
-    ret 0;
+    if (f.blocks.len < 1) { ret 1; }
+    if (f.blocks.data[0].inst_count == 4) { ret 0; }
+    ret 1;
 }
 
 test "codec: text round-trip preserves opcodes" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var m: mod.Module = build_test_module(?a);
     val pr: Result[bytebuf.WriteBuf, str] = printer.print(?a, ?m);
-    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 0; }
+    if (is_err[bytebuf.WriteBuf, str](pr)) { ret 1; }
     var buf: bytebuf.WriteBuf = unwrap_ok[bytebuf.WriteBuf, str](pr);
     val dr: Result[mod.Module, str] = parse(?a, buf.data, buf.len);
-    if (is_err[mod.Module, str](dr)) { ret 0; }
+    if (is_err[mod.Module, str](dr)) { ret 1; }
     var m2: mod.Module = unwrap_ok[mod.Module, str](dr);
-    if (m2.functions.len < 1) { ret 0; }
+    if (m2.functions.len < 1) { ret 1; }
     val f: *fn.Function = m2.functions.data[0];
-    if (f.blocks.len < 1) { ret 0; }
+    if (f.blocks.len < 1) { ret 1; }
     val b: *fn.Block = f.blocks.data[0];
-    if (b.inst_count != 4) { ret 0; }
-    if (b.insts[0].op != op.OP_MOVE) { ret 0; }
-    if (b.insts[1].op != op.OP_LOAD) { ret 0; }
-    if (b.insts[2].op != op.OP_ADD) { ret 0; }
-    if (b.insts[3].op != op.OP_RET) { ret 0; }
-    ret 1;
+    if (b.inst_count != 4) { ret 1; }
+    if (b.insts[0].op != op.OP_MOVE) { ret 1; }
+    if (b.insts[1].op != op.OP_LOAD) { ret 1; }
+    if (b.insts[2].op != op.OP_ADD) { ret 1; }
+    if (b.insts[3].op != op.OP_RET) { ret 1; }
+    ret 0;
 }

--- a/src/codec/decoder.mach
+++ b/src/codec/decoder.mach
@@ -5,13 +5,19 @@
 # symbol table, debug file table, functions (with pools, blocks, type
 # descriptors, debug locs), and data declarations.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_err;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
 
 use allocator: std.allocator;
-use bytebuf:   std.io.bytebuf;
+use bytebuf:   std.io.buffer;
 use vec:       std.collections.vector;
 use mem:       std.memory;
 
@@ -35,7 +41,7 @@ pub fun decode(alloc: *allocator.Allocator, raw: *u8, len: usize) Result[mod.Mod
         ret err[mod.Module, str]("nil argument");
     }
 
-    var buf: bytebuf.ReadBuf = bytebuf.rbuf_init(raw, len);
+    var buf: bytebuf.ReadBuf = bytebuf.rbuf_make(raw, len);
 
     val mr: Result[bool, str] = read_magic(?buf);
     if (is_err[bool, str](mr)) {

--- a/src/codec/encoder.mach
+++ b/src/codec/encoder.mach
@@ -9,13 +9,19 @@
 #   functions (header + pools + targets + type descs + blocks +
 #   instructions + debug locs) → data declarations
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_ok;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
 
 use allocator: std.allocator;
-use bytebuf:   std.io.bytebuf;
+use bytebuf:   std.io.buffer;
 use vec:       std.collections.vector;
 use mem:       std.memory;
 
@@ -55,7 +61,7 @@ pub fun encode(alloc: *allocator.Allocator, m: *mod.Module) Result[bytebuf.Write
 
     var st: symtab.Table = symtab.build_from_module(alloc, ?stb, m);
 
-    var buf: bytebuf.WriteBuf = bytebuf.wbuf_init(alloc);
+    var buf: bytebuf.WriteBuf = bytebuf.wbuf_make(alloc);
 
     write_header(?buf, m);
     write_strtab(?buf, ?stb);

--- a/src/codec/parser.mach
+++ b/src/codec/parser.mach
@@ -5,10 +5,18 @@
 # reconstruct data declarations, functions, blocks, and instructions with
 # their associated pools.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_err;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_len;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/codec/printer.mach
+++ b/src/codec/printer.mach
@@ -4,10 +4,14 @@
 # and data declaration is printed in a format that can be parsed back
 # by the text parser.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_ok;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_len;
 
 use allocator: std.allocator;
 use bytebuf:   std.io.buffer;

--- a/src/data.mach
+++ b/src/data.mach
@@ -5,10 +5,11 @@
 # bytes to sections directly. a separate emission pass materializes them
 # into object sections, creating symbols and relocations as needed.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.size.usize;
+use std.types.result.is_err;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/function.mach
+++ b/src/function.mach
@@ -4,10 +4,11 @@
 # creation, block management, and teardown. a Function owns its
 # blocks and per-function pools (constants, labels, metadata).
 
-use std.types.bool;
-use std.types.size;
-use std.types.string;
-use std.types.result;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.is_err;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/inst.mach
+++ b/src/inst.mach
@@ -4,7 +4,9 @@
 # meta byte encoding/decoding, field accessors, and all shape-specific
 # constructors for building instructions from typed parameters.
 
-use std.types.bool;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
 
 use op: masm.op;
 
@@ -582,43 +584,43 @@ pub fun is_valid_size(size: u8) bool {
 }
 
 test "inst: is_valid_size accepts powers of two" {
-    if (!is_valid_size(1))   { ret 0; }
-    if (!is_valid_size(2))   { ret 0; }
-    if (!is_valid_size(4))   { ret 0; }
-    if (!is_valid_size(8))   { ret 0; }
-    if (!is_valid_size(16))  { ret 0; }
-    if (!is_valid_size(32))  { ret 0; }
-    if (!is_valid_size(64))  { ret 0; }
-    if (!is_valid_size(128)) { ret 0; }
-    ret 1;
+    if (!is_valid_size(1))   { ret 1; }
+    if (!is_valid_size(2))   { ret 1; }
+    if (!is_valid_size(4))   { ret 1; }
+    if (!is_valid_size(8))   { ret 1; }
+    if (!is_valid_size(16))  { ret 1; }
+    if (!is_valid_size(32))  { ret 1; }
+    if (!is_valid_size(64))  { ret 1; }
+    if (!is_valid_size(128)) { ret 1; }
+    ret 0;
 }
 
 test "inst: is_valid_size rejects non-powers and zero" {
-    if (is_valid_size(0))  { ret 0; }
-    if (is_valid_size(3))  { ret 0; }
-    if (is_valid_size(5))  { ret 0; }
-    if (is_valid_size(6))  { ret 0; }
-    if (is_valid_size(7))  { ret 0; }
-    if (is_valid_size(10)) { ret 0; }
-    ret 1;
+    if (is_valid_size(0))  { ret 1; }
+    if (is_valid_size(3))  { ret 1; }
+    if (is_valid_size(5))  { ret 1; }
+    if (is_valid_size(6))  { ret 1; }
+    if (is_valid_size(7))  { ret 1; }
+    if (is_valid_size(10)) { ret 1; }
+    ret 0;
 }
 
 test "inst: encode_size and decode_size round-trip" {
-    if (decode_size(encode_size(1)) != 1) { ret 0; }
-    if (decode_size(encode_size(2)) != 2) { ret 0; }
-    if (decode_size(encode_size(4)) != 4) { ret 0; }
-    if (decode_size(encode_size(8)) != 8) { ret 0; }
-    ret 1;
+    if (decode_size(encode_size(1)) != 1) { ret 1; }
+    if (decode_size(encode_size(2)) != 2) { ret 1; }
+    if (decode_size(encode_size(4)) != 4) { ret 1; }
+    if (decode_size(encode_size(8)) != 8) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_meta packs cc, size, flag correctly" {
     val m: u8 = make_meta(5, 4, 1);
     var i: Instruction;
     i.meta = m;
-    if (cc(?i) != 5) { ret 0; }
-    if (size(?i) != 4) { ret 0; }
-    if (flag(?i) != 1) { ret 0; }
-    ret 1;
+    if (cc(?i) != 5) { ret 1; }
+    if (size(?i) != 4) { ret 1; }
+    if (flag(?i) != 1) { ret 1; }
+    ret 0;
 }
 
 test "inst: flag bit isolation" {
@@ -628,116 +630,116 @@ test "inst: flag bit isolation" {
     var i1: Instruction;
     i0.meta = m0;
     i1.meta = m1;
-    if (flag(?i0) != 0) { ret 0; }
-    if (flag(?i1) != 1) { ret 0; }
-    ret 1;
+    if (flag(?i0) != 0) { ret 1; }
+    if (flag(?i1) != 1) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_alu field layout" {
     val i: Instruction = make_alu(op.OP_ADD, 10, 20, 30, 8);
-    if (i.op != op.OP_ADD) { ret 0; }
-    if (dst_reg(?i) != 10) { ret 0; }
-    if (src1_reg(?i) != 20) { ret 0; }
-    if (src2_reg(?i) != 30) { ret 0; }
-    if (size(?i) != 8) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_ADD) { ret 1; }
+    if (dst_reg(?i) != 10) { ret 1; }
+    if (src1_reg(?i) != 20) { ret 1; }
+    if (src2_reg(?i) != 30) { ret 1; }
+    if (size(?i) != 8) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_cmp carries condition code" {
     val i: Instruction = make_cmp(1, 2, 3, op.CC_EQ, 4);
-    if (i.op != op.OP_CMP) { ret 0; }
-    if (cc(?i) != op.CC_EQ) { ret 0; }
-    if (size(?i) != 4) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_CMP) { ret 1; }
+    if (cc(?i) != op.CC_EQ) { ret 1; }
+    if (size(?i) != 4) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_jmp and make_label use f2 as label index" {
     val j: Instruction = make_jmp(7);
     val l: Instruction = make_label(7);
-    if (j.op != op.OP_JUMP) { ret 0; }
-    if (label_idx(?j) != 7) { ret 0; }
-    if (l.op != op.OP_LABEL) { ret 0; }
-    if (label_idx(?l) != 7) { ret 0; }
-    ret 1;
+    if (j.op != op.OP_JUMP) { ret 1; }
+    if (label_idx(?j) != 7) { ret 1; }
+    if (l.op != op.OP_LABEL) { ret 1; }
+    if (label_idx(?l) != 7) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_ret produces zero fields" {
     val i: Instruction = make_ret();
-    if (i.op != op.OP_RET) { ret 0; }
-    if (i.f0 != 0) { ret 0; }
-    if (i.f1 != 0) { ret 0; }
-    if (i.f2 != 0) { ret 0; }
-    if (size(?i) != 1) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_RET) { ret 1; }
+    if (i.f0 != 0) { ret 1; }
+    if (i.f1 != 0) { ret 1; }
+    if (i.f2 != 0) { ret 1; }
+    if (size(?i) != 1) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_ret_value carries register and type descriptor" {
     val i: Instruction = make_ret_value(10, 3, 8);
-    if (i.op != op.OP_RET) { ret 0; }
-    if (dst_reg(?i) != 10) { ret 0; }
-    if (i.f2 != 3) { ret 0; }
-    if (size(?i) != 8) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_RET) { ret 1; }
+    if (dst_reg(?i) != 10) { ret 1; }
+    if (i.f2 != 3) { ret 1; }
+    if (size(?i) != 8) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_call_direct with tail flag" {
     val i: Instruction = make_call_direct(5, 3, true, 8);
-    if (i.op != op.OP_CALL) { ret 0; }
-    if (dst_reg(?i) != 5) { ret 0; }
-    if (cc(?i) != op.CALL_TAIL) { ret 0; }
-    if (flag(?i) != 0) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_CALL) { ret 1; }
+    if (dst_reg(?i) != 5) { ret 1; }
+    if (cc(?i) != op.CALL_TAIL) { ret 1; }
+    if (flag(?i) != 0) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_call_indirect sets flag bit" {
     val i: Instruction = make_call_indirect(5, 10, false, 8);
-    if (i.op != op.OP_CALL) { ret 0; }
-    if (flag(?i) != 1) { ret 0; }
-    if (src1_reg(?i) != 10) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_CALL) { ret 1; }
+    if (flag(?i) != 1) { ret 1; }
+    if (src1_reg(?i) != 10) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_div modes" {
     val q: Instruction = make_div(1, 2, 3, op.DIV_QUOT, 8);
     val r: Instruction = make_div(1, 2, 3, op.DIV_REM, 8);
     val u: Instruction = make_div(1, 2, 3, op.DIV_UQUOT, 8);
-    if (q.op != op.OP_DIV) { ret 0; }
-    if (cc(?q) != op.DIV_QUOT) { ret 0; }
-    if (cc(?r) != op.DIV_REM) { ret 0; }
-    if (cc(?u) != op.DIV_UQUOT) { ret 0; }
-    ret 1;
+    if (q.op != op.OP_DIV) { ret 1; }
+    if (cc(?q) != op.DIV_QUOT) { ret 1; }
+    if (cc(?r) != op.DIV_REM) { ret 1; }
+    if (cc(?u) != op.DIV_UQUOT) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_conv kinds" {
     val z: Instruction = make_conv(1, 2, op.CONV_ZEXT, 8);
     val s: Instruction = make_conv(1, 2, op.CONV_SEXT, 8);
-    if (z.op != op.OP_CONV) { ret 0; }
-    if (cc(?z) != op.CONV_ZEXT) { ret 0; }
-    if (cc(?s) != op.CONV_SEXT) { ret 0; }
-    ret 1;
+    if (z.op != op.OP_CONV) { ret 1; }
+    if (cc(?z) != op.CONV_ZEXT) { ret 1; }
+    if (cc(?s) != op.CONV_SEXT) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_trap and make_hint" {
     val t: Instruction = make_trap();
     val h: Instruction = make_hint(op.HINT_PAUSE);
-    if (t.op != op.OP_TRAP) { ret 0; }
-    if (h.op != op.OP_HINT) { ret 0; }
-    if (cc(?h) != op.HINT_PAUSE) { ret 0; }
-    ret 1;
+    if (t.op != op.OP_TRAP) { ret 1; }
+    if (h.op != op.OP_HINT) { ret 1; }
+    if (cc(?h) != op.HINT_PAUSE) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_cmp_float sets flag" {
     val i: Instruction = make_cmp_float(1, 2, 3, op.CC_LT, 8);
-    if (i.op != op.OP_CMP) { ret 0; }
-    if (flag(?i) != 1) { ret 0; }
-    if (cc(?i) != op.CC_LT) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_CMP) { ret 1; }
+    if (flag(?i) != 1) { ret 1; }
+    if (cc(?i) != op.CC_LT) { ret 1; }
+    ret 0;
 }
 
 test "inst: make_scarg uses OP_ARG with flag=1" {
     val i: Instruction = make_scarg(2, 10, 8);
-    if (i.op != op.OP_ARG) { ret 0; }
-    if (flag(?i) != 1) { ret 0; }
-    if (dst_reg(?i) != 2) { ret 0; }
-    ret 1;
+    if (i.op != op.OP_ARG) { ret 1; }
+    if (flag(?i) != 1) { ret 1; }
+    if (dst_reg(?i) != 2) { ret 1; }
+    ret 0;
 }

--- a/src/main.mach
+++ b/src/main.mach
@@ -5,12 +5,19 @@
 # and help.
 
 use std.runtime;
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.result.is_err;
+use std.types.result.Result;
+use std.types.result.unwrap_err;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_equals;
 
 use alloc: std.allocator;
+use page:  std.allocator.page;
 use print: std.print;
 
 use fn:     masm.function;
@@ -53,7 +60,8 @@ fun cmd_compile(argc: i64, argv: **u8) i64 {
         output = "out.mo";
     }
 
-    var a: alloc.Allocator = alloc.default();
+    var a: alloc.Allocator;
+    page.make(?a);
 
     val pr: Result[mod.Module, str] = codec.parse_file(?a, input);
     if (is_err[mod.Module, str](pr)) {
@@ -87,7 +95,8 @@ fun cmd_print(argc: i64, argv: **u8) i64 {
         output = "/dev/stdout";
     }
 
-    var a: alloc.Allocator = alloc.default();
+    var a: alloc.Allocator;
+    page.make(?a);
 
     val dr: Result[mod.Module, str] = codec.decode_file(?a, input);
     if (is_err[mod.Module, str](dr)) {
@@ -115,7 +124,8 @@ fun cmd_info(argc: i64, argv: **u8) i64 {
     }
 
     val input: str = argv[2];
-    var a: alloc.Allocator = alloc.default();
+    var a: alloc.Allocator;
+    page.make(?a);
 
     val dr: Result[mod.Module, str] = codec.decode_file(?a, input);
     var m: mod.Module;
@@ -178,7 +188,8 @@ fun cmd_verify(argc: i64, argv: **u8) i64 {
     }
 
     val input: str = argv[2];
-    var a: alloc.Allocator = alloc.default();
+    var a: alloc.Allocator;
+    page.make(?a);
 
     val dr: Result[mod.Module, str] = codec.decode_file(?a, input);
     var m: mod.Module;

--- a/src/module.mach
+++ b/src/module.mach
@@ -6,10 +6,16 @@
 # passes. codegen-local state (sections, symbols, debug lines) lives
 # outside the Module.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_equals;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/op.mach
+++ b/src/op.mach
@@ -4,8 +4,9 @@
 # and flag fields. dot suffixes are a textual representation — the
 # binary encoding is unchanged (8-byte Instruction record).
 
-use std.types.bool;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.string.str;
 
 pub def Operator: u8;
 pub def Cond:     u8;
@@ -368,56 +369,56 @@ pub fun is_valid_cc(o: u8, cc: u8) bool {
 }
 
 test "op: is_valid_div_mode" {
-    if (!is_valid_div_mode(DIV_QUOT))  { ret 0; }
-    if (!is_valid_div_mode(DIV_FLOAT)) { ret 0; }
-    if (is_valid_div_mode(5))          { ret 0; }
-    ret 1;
+    if (!is_valid_div_mode(DIV_QUOT))  { ret 1; }
+    if (!is_valid_div_mode(DIV_FLOAT)) { ret 1; }
+    if (is_valid_div_mode(5))          { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_conv_kind" {
-    if (!is_valid_conv_kind(CONV_ZEXT))   { ret 0; }
-    if (!is_valid_conv_kind(CONV_FTRUNC)) { ret 0; }
-    if (is_valid_conv_kind(7))            { ret 0; }
-    ret 1;
+    if (!is_valid_conv_kind(CONV_ZEXT))   { ret 1; }
+    if (!is_valid_conv_kind(CONV_FTRUNC)) { ret 1; }
+    if (is_valid_conv_kind(7))            { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_mo" {
-    if (!is_valid_mo(MO_RELAXED)) { ret 0; }
-    if (!is_valid_mo(MO_SEQ_CST)) { ret 0; }
-    if (is_valid_mo(5))           { ret 0; }
-    ret 1;
+    if (!is_valid_mo(MO_RELAXED)) { ret 1; }
+    if (!is_valid_mo(MO_SEQ_CST)) { ret 1; }
+    if (is_valid_mo(5))           { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_rmw_op" {
-    if (!is_valid_rmw_op(RMW_ADD))  { ret 0; }
-    if (!is_valid_rmw_op(RMW_XCHG)) { ret 0; }
-    if (is_valid_rmw_op(6))         { ret 0; }
-    ret 1;
+    if (!is_valid_rmw_op(RMW_ADD))  { ret 1; }
+    if (!is_valid_rmw_op(RMW_XCHG)) { ret 1; }
+    if (is_valid_rmw_op(6))         { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_cc for cmp accepts condition codes" {
-    if (!is_valid_cc(OP_CMP, CC_EQ))  { ret 0; }
-    if (!is_valid_cc(OP_CMP, CC_UGE)) { ret 0; }
-    if (is_valid_cc(OP_CMP, 11))      { ret 0; }
-    ret 1;
+    if (!is_valid_cc(OP_CMP, CC_EQ))  { ret 1; }
+    if (!is_valid_cc(OP_CMP, CC_UGE)) { ret 1; }
+    if (is_valid_cc(OP_CMP, 11))      { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_cc for add accepts 0 and ALU_FLOAT" {
-    if (!is_valid_cc(OP_ADD, 0))         { ret 0; }
-    if (!is_valid_cc(OP_ADD, ALU_FLOAT)) { ret 0; }
-    if (is_valid_cc(OP_ADD, 2))          { ret 0; }
-    ret 1;
+    if (!is_valid_cc(OP_ADD, 0))         { ret 1; }
+    if (!is_valid_cc(OP_ADD, ALU_FLOAT)) { ret 1; }
+    if (is_valid_cc(OP_ADD, 2))          { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_cc for div accepts division modes" {
-    if (!is_valid_cc(OP_DIV, DIV_QUOT))  { ret 0; }
-    if (!is_valid_cc(OP_DIV, DIV_FLOAT)) { ret 0; }
-    if (is_valid_cc(OP_DIV, 5))          { ret 0; }
-    ret 1;
+    if (!is_valid_cc(OP_DIV, DIV_QUOT))  { ret 1; }
+    if (!is_valid_cc(OP_DIV, DIV_FLOAT)) { ret 1; }
+    if (is_valid_cc(OP_DIV, 5))          { ret 1; }
+    ret 0;
 }
 
 test "op: is_valid_cc for fence accepts memory orderings" {
-    if (!is_valid_cc(OP_FENCE, MO_SEQ_CST)) { ret 0; }
-    if (is_valid_cc(OP_FENCE, 5))           { ret 0; }
-    ret 1;
+    if (!is_valid_cc(OP_FENCE, MO_SEQ_CST)) { ret 1; }
+    if (is_valid_cc(OP_FENCE, 5))           { ret 1; }
+    ret 0;
 }

--- a/src/pool.mach
+++ b/src/pool.mach
@@ -7,12 +7,19 @@
 # data_get resolves it directly. pools own their backing memory and grow
 # geometrically.
 
-use std.types.bool;
-use std.types.size;
-use std.types.string;
-use std.types.result;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_equals;
+use std.types.result.is_err;
+use std.types.result.is_ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use dbg:       std.print;
 use map:       std.collections.map;
 
@@ -462,82 +469,90 @@ pub fun data_length(pool: *DataPool) i32 {
 }
 
 test "pool: const_intern returns index 0 for first value" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: ConstPool = const_init(?a);
     val idx: i32 = const_intern(?a, ?p, 42);
     const_dnit(?a, ?p);
-    if (idx == 0) { ret 1; }
-    ret 0;
+    if (idx == 0) { ret 0; }
+    ret 1;
 }
 
 test "pool: const_get retrieves interned value" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: ConstPool = const_init(?a);
     const_intern(?a, ?p, 12345);
     val v: u64 = const_get(?p, 0);
     const_dnit(?a, ?p);
-    if (v == 12345) { ret 1; }
-    ret 0;
+    if (v == 12345) { ret 0; }
+    ret 1;
 }
 
 test "pool: const_intern deduplicates same value" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: ConstPool = const_init(?a);
     val i0: i32 = const_intern(?a, ?p, 99);
     val i1: i32 = const_intern(?a, ?p, 99);
     const_dnit(?a, ?p);
-    if (i0 == i1) { ret 1; }
-    ret 0;
+    if (i0 == i1) { ret 0; }
+    ret 1;
 }
 
 test "pool: const_intern assigns different indices for different values" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: ConstPool = const_init(?a);
     val i0: i32 = const_intern(?a, ?p, 10);
     val i1: i32 = const_intern(?a, ?p, 20);
     const_dnit(?a, ?p);
-    if (i0 != i1) { ret 1; }
-    ret 0;
+    if (i0 != i1) { ret 0; }
+    ret 1;
 }
 
 test "pool: label_intern and label_get round-trip" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var t: LabelTable = label_init(?a);
     val idx: i32 = label_intern(?a, ?t, "entry");
     val name: str = label_get(?t, idx);
     label_dnit(?a, ?t);
-    if (str_equals(name, "entry")) { ret 1; }
-    ret 0;
+    if (str_equals(name, "entry")) { ret 0; }
+    ret 1;
 }
 
 test "pool: label_intern deduplicates same name" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var t: LabelTable = label_init(?a);
     val i0: i32 = label_intern(?a, ?t, "loop");
     val i1: i32 = label_intern(?a, ?t, "loop");
     label_dnit(?a, ?t);
-    if (i0 == i1) { ret 1; }
-    ret 0;
+    if (i0 == i1) { ret 0; }
+    ret 1;
 }
 
 test "pool: data_intern_i32 and data_get_i32 round-trip" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: DataPool = data_init(?a);
     val off: i32 = data_intern_i32(?a, ?p, 777);
     val v: i32 = data_get_i32(?p, off);
     data_dnit(?a, ?p);
-    if (v == 777) { ret 1; }
-    ret 0;
+    if (v == 777) { ret 0; }
+    ret 1;
 }
 
 test "pool: data_intern deduplicates identical bytes" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var p: DataPool = data_init(?a);
     var val1: i32 = 42;
     var val2: i32 = 42;
     val o1: i32 = data_intern(?a, ?p, (?val1)::*u8, 4);
     val o2: i32 = data_intern(?a, ?p, (?val2)::*u8, 4);
     data_dnit(?a, ?p);
-    if (o1 == o2) { ret 1; }
-    ret 0;
+    if (o1 == o2) { ret 0; }
+    ret 1;
 }

--- a/src/strtab.mach
+++ b/src/strtab.mach
@@ -3,13 +3,16 @@
 # packed null-terminated strings referenced by u32 byte offset.
 # deduplicates on intern. used by the binary .mo encoder/decoder.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.result.is_ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
+use std.types.string.str_equals;
 
 use allocator: std.allocator;
-use bytebuf:   std.io.bytebuf;
+use page:      std.allocator.page;
+use bytebuf:   std.io.buffer;
 use map:       std.collections.map;
 
 # Builder: string table builder for encoding
@@ -31,7 +34,7 @@ pub rec Builder {
 # ret:   initialized builder
 pub fun stb_init(alloc: *allocator.Allocator) Builder {
     var b: Builder;
-    b.buf = bytebuf.wbuf_init(alloc);
+    b.buf = bytebuf.wbuf_make(alloc);
     b.dedup = map.init[str, u32](alloc, map.hash_str, map.eq_str);
     ret b;
 }
@@ -128,26 +131,29 @@ pub fun str_get(r: *Reader, offset: u32) str {
 }
 
 test "strtab: intern returns offset for first string" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var b: Builder = stb_init(?a);
     val off: u32 = stb_intern(?b, "hello");
     stb_dnit(?b);
-    if (off == 0) { ret 1; }
-    ret 0;
+    if (off == 0) { ret 0; }
+    ret 1;
 }
 
 test "strtab: intern deduplicates same string" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var b: Builder = stb_init(?a);
     val o1: u32 = stb_intern(?b, "test");
     val o2: u32 = stb_intern(?b, "test");
     stb_dnit(?b);
-    if (o1 == o2) { ret 1; }
-    ret 0;
+    if (o1 == o2) { ret 0; }
+    ret 1;
 }
 
 test "strtab: reader retrieves interned string" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var b: Builder = stb_init(?a);
     val off: u32 = stb_intern(?b, "world");
     val data: *u8 = stb_data(?b);
@@ -156,12 +162,13 @@ test "strtab: reader retrieves interned string" {
     val s: str = str_get(?r, off);
     val eq: bool = str_equals(s, "world");
     stb_dnit(?b);
-    if (eq) { ret 1; }
-    ret 0;
+    if (eq) { ret 0; }
+    ret 1;
 }
 
 test "strtab: multiple strings have distinct offsets" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var b: Builder = stb_init(?a);
     val o1: u32 = stb_intern(?b, "alpha");
     val o2: u32 = stb_intern(?b, "beta");
@@ -173,6 +180,6 @@ test "strtab: multiple strings have distinct offsets" {
     val eq1: bool = str_equals(s1, "alpha");
     val eq2: bool = str_equals(s2, "beta");
     stb_dnit(?b);
-    if (o1 != o2 && eq1 && eq2) { ret 1; }
-    ret 0;
+    if (o1 != o2 && eq1 && eq2) { ret 0; }
+    ret 1;
 }

--- a/src/symbol.mach
+++ b/src/symbol.mach
@@ -8,9 +8,11 @@
 # MASM is the canonical source for these constants. object format
 # implementations consume them — they do not redefine them.
 
-use std.types.bool;
-use std.types.size;
-use std.types.string;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
 
 pub def SymBinding: u8;
 

--- a/src/symtab.mach
+++ b/src/symtab.mach
@@ -4,10 +4,12 @@
 # declarations. used by the binary encoder to write symbol entries
 # and by the decoder to reconstruct module-level symbol information.
 
-use std.types.bool;
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.size.usize;
+use std.types.result.is_err;
+use std.types.result.is_ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/typedesc.mach
+++ b/src/typedesc.mach
@@ -6,9 +6,11 @@
 # their f2 field. this gives any ABI lowering pass the type information it
 # needs without encoding ABI-specific metadata into the instruction format.
 
-use std.types.size;
-use std.types.result;
-use std.types.string;
+use std.types.size.usize;
+use std.types.result.is_err;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
+use std.types.string.str;
 
 use allocator: std.allocator;
 use vec:       std.collections.vector;

--- a/src/verify.mach
+++ b/src/verify.mach
@@ -194,7 +194,7 @@ fun verify_load_store(i: *inst.Instruction, flag: u8,
 fun verify_addr(i: *inst.Instruction, cc: u8, flag: u8,
                 data_len: i32, lbl_count: i32) Result[bool, str] {
     if (cc == 1 && flag == 0) {
-        if (i.f2::i32 >= lbl_count && lbl_count > 0) {
+        if (i.f2::i32 >= lbl_count) {
             ret err[bool, str]("addr.label f2 exceeds label table");
         }
         ret ok[bool, str](true);
@@ -219,14 +219,14 @@ fun verify_jmp(i: *inst.Instruction, lbl_count: i32) Result[bool, str] {
     if (i.f0 != 0 || i.f1 != 0) {
         ret err[bool, str]("jmp f0/f1 must be zero");
     }
-    if (lbl_count > 0 && i.f2::i32 >= lbl_count) {
+    if (i.f2::i32 >= lbl_count) {
         ret err[bool, str]("jmp f2 exceeds label table");
     }
     ret ok[bool, str](true);
 }
 
 fun verify_branch(i: *inst.Instruction, lbl_count: i32) Result[bool, str] {
-    if (lbl_count > 0 && i.f2::i32 >= lbl_count) {
+    if (i.f2::i32 >= lbl_count) {
         ret err[bool, str]("branch f2 exceeds label table");
     }
     ret ok[bool, str](true);
@@ -235,7 +235,7 @@ fun verify_branch(i: *inst.Instruction, lbl_count: i32) Result[bool, str] {
 fun verify_call(i: *inst.Instruction, flag: u8,
                 lbl_count: i32) Result[bool, str] {
     if (flag == 0) {
-        if (lbl_count > 0 && i.f2::i32 >= lbl_count) {
+        if (i.f2::i32 >= lbl_count) {
             ret err[bool, str]("call.direct f2 exceeds label table");
         }
     }
@@ -261,7 +261,7 @@ fun verify_label(i: *inst.Instruction, lbl_count: i32) Result[bool, str] {
     if (i.f0 != 0 || i.f1 != 0) {
         ret err[bool, str]("label f0/f1 must be zero");
     }
-    if (lbl_count > 0 && i.f2::i32 >= lbl_count) {
+    if (i.f2::i32 >= lbl_count) {
         ret err[bool, str]("label f2 exceeds label table");
     }
     ret ok[bool, str](true);

--- a/src/verify.mach
+++ b/src/verify.mach
@@ -5,12 +5,20 @@
 # terminated, and per-opcode field constraints met. returns err with a
 # descriptive message on the first violation found.
 
-use std.types.bool;
-use std.types.size;
-use std.types.string;
-use std.types.result;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.result.err;
+use std.types.result.is_err;
+use std.types.result.is_ok;
+use std.types.result.ok;
+use std.types.result.Result;
+use std.types.result.unwrap_ok;
 
 use allocator: std.allocator;
+use page:      std.allocator.page;
 use vec:       std.collections.vector;
 
 use op:       masm.op;
@@ -311,12 +319,13 @@ fun verify_hint(i: *inst.Instruction) Result[bool, str] {
 }
 
 test "verify: valid function passes" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "test");
 
     val lbl: i32 = pool.label_intern(?a, ?func.labels, ".entry");
     val r: Result[*fn.Block, str] = allocator.allocate[fn.Block](?a, 1);
-    if (is_err[*fn.Block, str](r)) { ret 0; }
+    if (is_err[*fn.Block, str](r)) { ret 1; }
     val blk: *fn.Block = unwrap_ok[*fn.Block, str](r);
     @blk = fn.block_init(".entry");
 
@@ -326,26 +335,28 @@ test "verify: valid function passes" {
 
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_ok[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_ok[bool, str](vr)) { ret 0; }
+    ret 1;
 }
 
 test "verify: empty function fails" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "empty");
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_err[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_err[bool, str](vr)) { ret 0; }
+    ret 1;
 }
 
 test "verify: missing terminator fails" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "noterm");
 
     val lbl: i32 = pool.label_intern(?a, ?func.labels, ".entry");
     val r: Result[*fn.Block, str] = allocator.allocate[fn.Block](?a, 1);
-    if (is_err[*fn.Block, str](r)) { ret 0; }
+    if (is_err[*fn.Block, str](r)) { ret 1; }
     val blk: *fn.Block = unwrap_ok[*fn.Block, str](r);
     @blk = fn.block_init(".entry");
 
@@ -354,16 +365,17 @@ test "verify: missing terminator fails" {
 
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_err[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_err[bool, str](vr)) { ret 0; }
+    ret 1;
 }
 
 test "verify: bad label index fails" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "badlbl");
 
     val r: Result[*fn.Block, str] = allocator.allocate[fn.Block](?a, 1);
-    if (is_err[*fn.Block, str](r)) { ret 0; }
+    if (is_err[*fn.Block, str](r)) { ret 1; }
     val blk: *fn.Block = unwrap_ok[*fn.Block, str](r);
     @blk = fn.block_init(".entry");
 
@@ -372,16 +384,17 @@ test "verify: bad label index fails" {
 
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_err[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_err[bool, str](vr)) { ret 0; }
+    ret 1;
 }
 
 test "verify: trap instruction passes" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "trap");
 
     val r: Result[*fn.Block, str] = allocator.allocate[fn.Block](?a, 1);
-    if (is_err[*fn.Block, str](r)) { ret 0; }
+    if (is_err[*fn.Block, str](r)) { ret 1; }
     val blk: *fn.Block = unwrap_ok[*fn.Block, str](r);
     @blk = fn.block_init(".entry");
 
@@ -390,17 +403,18 @@ test "verify: trap instruction passes" {
 
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_ok[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_ok[bool, str](vr)) { ret 0; }
+    ret 1;
 }
 
 test "verify: terminator mid-block fails" {
-    var a: allocator.Allocator = allocator.default();
+    var a: allocator.Allocator;
+    page.make(?a);
     var func: fn.Function = fn.func_init(?a, "midterm");
 
     val lbl: i32 = pool.label_intern(?a, ?func.labels, ".entry");
     val r: Result[*fn.Block, str] = allocator.allocate[fn.Block](?a, 1);
-    if (is_err[*fn.Block, str](r)) { ret 0; }
+    if (is_err[*fn.Block, str](r)) { ret 1; }
     val blk: *fn.Block = unwrap_ok[*fn.Block, str](r);
     @blk = fn.block_init(".entry");
 
@@ -410,6 +424,6 @@ test "verify: terminator mid-block fails" {
 
     val vr: Result[bool, str] = verify_function(?func);
     fn.func_dnit(?a, ?func);
-    if (is_err[bool, str](vr)) { ret 1; }
-    ret 0;
+    if (is_err[bool, str](vr)) { ret 0; }
+    ret 1;
 }


### PR DESCRIPTION
Closes #90. Closes #92.

Rebuilds mach-masm against mach v1.0.0 and current `mach-std` (`dev` @ `32141ea`). The sources predated the 2026-03-21 std/compiler snapshot and no longer compiled.

## Drift fixed
- **Imports** — the dialect dropped glob-import of a module's symbols via module-form `use std.types.X;`. Expanded every such import into the explicit per-symbol form (`use std.types.string.str;`, …) actually referenced by each file.
- **byte buffer** — `std.io.bytebuf` → `std.io.buffer`; `wbuf_init`/`rbuf_init` → `wbuf_make`/`rbuf_make`.
- **allocator** — removed `allocator.default()`; allocators are now built via a backend. Replaced with a declared `Allocator` + `page.make(?a)` (importing `std.allocator.page`).
- **filesystem** — `fs.file_write`/`fs.file_read`/`fs.file_close`/`fs.file_stat` → `fs.write`/`fs.read`/`fs.close`/`fs.info`; `fs.Stat`/`st_size` → `fs.FileInfo`/`size`.
- **tests** — flipped in-tree tests to the canonical `0=pass` convention to match the current runner (mirrors the std-side flip).
- **dep pin** — bumped the `mach-std` submodule to current `dev`.

## Verifier fix (#92)
The convention flip surfaced a latent verifier gap: `verify_jmp`/`verify_branch`/`verify_label`/addr guarded their out-of-bounds label check with `lbl_count > 0`, silently disabling validation for functions with an empty label table — so `make_jmp(999)` with no interned labels passed verification. Dropped the guard; instructions that don't reference labels never reach these checks, so any `f2 >= lbl_count` is genuinely out of bounds.

## Status
- `mach build .` — clean.
- `mach test .` — **220 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)